### PR TITLE
Fix AWS credentials access in Anthropic::Bedrock::Client

### DIFF
--- a/lib/anthropic/bedrock/client.rb
+++ b/lib/anthropic/bedrock/client.rb
@@ -197,7 +197,7 @@ module Anthropic
         end
 
         bedrock_client = Aws::BedrockRuntime::Client.new(client_options)
-        [bedrock_client.config.region, bedrock_client.config.credentials]
+        [bedrock_client.config.region, bedrock_client.config.credentials.credentials]
       end
 
       # @private


### PR DESCRIPTION
When testing the sample application locally I stumbled upon the following exception:

```
 :030 > r = c.messages.create(max_tokens: 1024, messages: [ { role: 'user', content: 'hello' } ], model:
/Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/gems/aws-sigv4-1.11.0/lib/aws-sigv4/signer.rb:760:in

        !credentials.access_key_id.nil? &&
                    ^^^^^^^^^^^^^^
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/gems/aws-sigv4-1.11.0/lib/aws-sigv4/signer.rb:743:in 'Aws::Sigv4::Signer#fetch_credentials'
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/gems/aws-sigv4-1.11.0/lib/aws-sigv4/signer.rb:223:in 'Aws::Sigv4::Signer#sign_request'
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/gems/anthropic-sdk-beta-0.1.0.pre.beta.6/lib/anthropic/bedrock/client.rb:158:in 'Anthropic::Bedrock::Client#build_request'
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/gems/anthropic-sdk-beta-0.1.0.pre.beta.6/lib/anthropic/internal/transport/base_client.rb:439:in 'Anthropic::Internal::Transport::BaseClient#request'
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/gems/anthropic-sdk-beta-0.1.0.pre.beta.6/lib/anthropic/resources/messages.rb:44:in 'Anthropic::Resources::Messages#create'
        from (irb):30:in '<main>'
        from <internal:kernel>:191:in 'Kernel#loop'
        from /Users/artem.shubovych/.rvm/rubies/ruby-3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/irb-1.13.1/exe/irb:9:in '<top (required)>'
        from /Users/artem.shubovych/.rvm/rubies/ruby-3.4.0-preview1/bin/irb:25:in 'Kernel#load'
        from /Users/artem.shubovych/.rvm/rubies/ruby-3.4.0-preview1/bin/irb:25:in '<main>'
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/bin/ruby_executable_hooks:22:in 'Kernel#eval'
        from /Users/artem.shubovych/.rvm/gems/ruby-3.4.0-preview1/bin/ruby_executable_hooks:22:in '<main>'
```

This was happening in a _very_ simple use case:

```rb
require 'bundler/setup'
require 'anthropic'

c = Anthropic::Bedrock::Client::new(aws_region: 'us-east-1', aws_profile: 'moo-dev')
r = c.messages.create(max_tokens: 1024, messages: [ { role: 'user', content: 'hello' } ], model: 'us.anthropic.claude-3-5-haiku-20241022-v1:0')
```

with the following gems in the `Gemfile`:

```rb
gem "anthropic-sdk-beta", "~> 0.1.0.pre.beta.6"
gem "aws-sdk-bedrockruntime", "~> 1.48"
```

The `moo-dev` profile exists and is correct in `~/.aws/credentials` (I was able to get it working with the Python SDK).

Upon debugging in `irb`, I figured the object returned by the `Aws::BedrockRuntime::Client.new` call in the `Anthropic::Bedrock::Client::resolve_region_and_credentials` method is [`Aws::SharedCredentials`](http://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SharedCredentials.html), which does not have a direct `access_key_id` accessor. But it does have a `credentials` accessor, which in turn has `access_key_id`.

So working around the issue by storing the `Aws::Credentials` object instead of `Aws::SharedCredentials`.