### PR TITLE
chore: add `license` to the gemspec

### DIFF
--- a/anthropic.gemspec
+++ b/anthropic.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["Anthropic"]
   s.email = "support@anthropic.com"
   s.homepage = "https://gemdocs.org/gems/anthropic"
+  s.license  = "MIT"
   s.metadata["homepage_uri"] = s.homepage
   s.metadata["source_code_uri"] = "https://github.com/anthropics/anthropic-sdk-ruby"
   s.metadata["rubygems_mfa_required"] = false.to_s


### PR DESCRIPTION
Currently, `Licenses` in https://rubygems.org/gems/anthropic doesn't show. This is because `license` isn't written in the gemspec.
This PR adds it to show the `Licenses` in the rubygems.