### PR TITLE
Unify RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,10 @@ Layout/LineLength:
     - "Anthropic::Internal::Type::BaseModel$"
     - "^\\s*[A-Z0-9_]+ = :"
     - "Anthropic::(Models|Resources|Test)::"
+    - "projects/.*/locations/.*/publishers/anthropic/models/"
+    - "T::Class\\[Anthropic::Internal::Type::"
+    - "Anthropic::Internal::Type::ArrayOf\\["
+    - "\\.params\\(.*opts: Anthropic::Internal::AnyHash\\)"
   Max: 110
 
 Layout/MultilineArrayLineBreaks:

--- a/Rakefile
+++ b/Rakefile
@@ -45,9 +45,6 @@ multitask(:"lint:rubocop") do
   rubocop = %w[rubocop]
   rubocop += %w[--format github] if ENV.key?("CI")
 
-  # some lines cannot be shortened
-  rubocop += %w[--except Lint/RedundantCopDisableDirective,Layout/LineLength]
-
   lint = xargs + rubocop
   sh("#{find.shelljoin} | #{lint.shelljoin}")
 end


### PR DESCRIPTION
I noticed that `rake lint:rubocop` was giving different results than `rubocop .`. This is because the Rakefile was adding some additional configuration. I think it's better to keep it all in one place?