### PR TITLE
chore(ci): setup Ruby on release job

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -22,7 +22,6 @@ jobs:
           repo: ${{ github.event.repository.full_name }}
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
-      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -22,6 +22,12 @@ jobs:
           repo: ${{ github.event.repository.full_name }}
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+
       - name: Publish to RubyGems.org
         if: ${{ steps.release.outputs.releases_created }}
         run: |


### PR DESCRIPTION
This job uses `bundle` to release a gem. So we need to setup Ruby to use it

Ref: https://github.com/anthropics/anthropic-sdk-ruby/actions/runs/16371892051/job/46262067860