### PR TITLE
feat: update streaming error message to say 'required' not 'recommended'

### DIFF
--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -78,7 +78,7 @@ module Anthropic
       expected_time = maximum_time * max_tokens / 128_000.0
       if expected_time > default_time || (max_nonstreaming_tokens && max_tokens > max_nonstreaming_tokens)
         raise ArgumentError.new(
-          "Streaming is strongly recommended for operations that may take longer than 10 minutes. " \
+          "Streaming is required for operations that may take longer than 10 minutes. " \
           "See https://github.com/anthropics/anthropic-sdk-ruby#long-requests for more details"
         )
       end


### PR DESCRIPTION
Updates the error message from 'streaming is strongly recommended' to 'streaming is required' for consistency across all Anthropic SDKs.

## Changes
Changes the error message in timeout calculation function from 'strongly recommended' to 'required' when streaming is needed for operations that may take longer than 10 minutes.

## Related
CE-732

🤖 Generated with [Claude Code](https://claude.ai/code)