### PR TITLE
Fix broken attr_accessor sigs

### DIFF
--- a/rbi/anthropic/errors.rbi
+++ b/rbi/anthropic/errors.rbi
@@ -60,10 +60,20 @@ module Anthropic
 
     class APIConnectionError < Anthropic::Errors::APIError
       sig { void }
-      attr_accessor :status
+      def status
+      end
+
+      sig { params(_: NilClass).void }
+      def status=(_)
+      end
 
       sig { void }
-      attr_accessor :body
+      def body
+      end
+
+      sig { params(_: NilClass).void }
+      def body=(_)
+      end
 
       # @api private
       sig do


### PR DESCRIPTION
It's [no longer allowed](https://github.com/sorbet/sorbet/pull/9145) to annotate `attr_accessor` with `void`. This was causing a [type error](https://sorbet.org/docs/error-reference#3516) in a project that used the `anthropic` gem with Tapioca and Sorbet.

This commit fixes the broken sigs by reverting to [an earlier version of the code](https://github.com/anthropics/anthropic-sdk-ruby/commit/e1693fda586a70d6a0dc01b7bb8c290fd6343b01#diff-145d235fbb36308bb451f4c1d48f0202bafef8c84ff2aa62dd365722a5ade413) that annotated getter and setter methods separately.

There are other options to address this—such as `returns(NilClass)`—but I believe the intention of the original code was to communicate that these attributes do not return anything and should not be used.