### PR TITLE
fix: unnecessarily long multipart boundary length

### DIFF
--- a/lib/anthropic/internal/util.rb
+++ b/lib/anthropic/internal/util.rb
@@ -566,7 +566,7 @@ module Anthropic
         #
         # @return [Array(String, Enumerable<String>)]
         private def encode_multipart_streaming(body)
-          boundary = SecureRandom.urlsafe_base64(60)
+          boundary = SecureRandom.urlsafe_base64(30)
 
           closing = []
           strio = writable_enum do |y|


### PR DESCRIPTION
Previously multipart boundary lengths were [generated with 80 characters](https://github.com/anthropics/anthropic-sdk-ruby/blob/9b9be231a1677c073f1bd6a341f15b56f9a6ec54/lib/anthropic/internal/util.rb#L569). Most web clients generate boundary lengths between 20 and 40 characters, so the unusually long boundary created some minor issues:

- Rack, and possibly other webserver interfaces, [raises an exception for boundaries over 70 characters](https://github.com/rack/rack/blob/8116397b447e6dc8117c8409cc083bf5b0e2f8fb/lib/rack/multipart/parser.rb#L107). That caused Rack to raise an exception in the test environment when stubbing the Anthropic service using the [thoughtbot approach](https://thoughtbot.com/blog/how-to-stub-external-services-in-tests): "Rack::Multipart::BoundaryTooLongError - multipart boundary size too large (80 characters)".
- Some risk of future boundary errors in production if the Anthropic API ever imposes a similar constraint on boundary length.

This solves the problem by reducing the boundary length from 80 characters to 40.

## More info

- `SecureRandom.urlsafe_base64(60).length` => 80
- `SecureRandom.urlsafe_base64(30).length` => 40
- `SecureRandom.uuid.length` => 36 (this is what [multipart-post gem uses](https://github.com/socketry/multipart-post/blob/cce3634876b74e08a6c51d02db00070a82dc8cc4/lib/multipart/post/multipartable.rb#L35))

P.S. This is a great gem, thanks for creating it! 💙 