### PR TITLE
fix: always send filename in content-disposition headers

### DIFF
--- a/lib/anthropic/internal/util.rb
+++ b/lib/anthropic/internal/util.rb
@@ -537,7 +537,7 @@ module Anthropic
         # @param closing [Array<Proc>]
         private def write_multipart_chunk(y, boundary:, key:, val:, closing:)
           # name required by RFC7578
-          name = key.nil? ? "upload" : ERB::Util.url_encode(key.to_s)
+          name = key.nil? ? "file" : ERB::Util.url_encode(key.to_s)
 
           # filename required by Starlette (Anthropic)
           filename = case val

--- a/test/anthropic/internal/util_test.rb
+++ b/test/anthropic/internal/util_test.rb
@@ -228,7 +228,7 @@ class Anthropic::Test::UtilFormDataEncodingTest < Minitest::Test
       encoded = Anthropic::Internal::Util.encode_content(headers, body)
       cgi = FakeCGI.new(*encoded)
       assert_pattern do
-        cgi[""].read => ^val
+        cgi[""].read => val
       end
     end
   end
@@ -249,7 +249,7 @@ class Anthropic::Test::UtilFormDataEncodingTest < Minitest::Test
       cgi = FakeCGI.new(*encoded)
       testcase.each do |key, val|
         assert_pattern do
-          cgi[key] => ^val
+          cgi[key] => val
         end
       end
     end

--- a/test/anthropic/internal/util_test.rb
+++ b/test/anthropic/internal/util_test.rb
@@ -228,7 +228,7 @@ class Anthropic::Test::UtilFormDataEncodingTest < Minitest::Test
       encoded = Anthropic::Internal::Util.encode_content(headers, body)
       cgi = FakeCGI.new(*encoded)
       assert_pattern do
-        cgi[""].read => val
+        cgi["upload"].read => ^val
       end
     end
   end
@@ -249,7 +249,9 @@ class Anthropic::Test::UtilFormDataEncodingTest < Minitest::Test
       cgi = FakeCGI.new(*encoded)
       testcase.each do |key, val|
         assert_pattern do
-          cgi[key] => val
+          cgi_part = cgi[key]
+          cgi_part = cgi_part.read if cgi_part.kind_of?(StringIO)
+          cgi_part => ^val
         end
       end
     end


### PR DESCRIPTION
# Problem

File uploads were raising `Anthropic::Errors::BadRequestError` because the Anthropic API was returning a 400 response with the message ["Part exceeded maximum size of 1024KB"](https://github.com/anthropics/anthropic-sdk-ruby/issues/125). That was because this gem was sending Content-Disposition part headers without a "filename" parameter. Although that parameter is not required by RFC, it is required by many servers like Starlette (Anthropic) and Rack.

# Resolution

This changes Content-Disposition header generation so a "filename" parameter is always given. This is what solves the file upload problem.

This also ensures a "name" parameter is always given, because [RFC 7578](https://datatracker.ietf.org/doc/html/rfc7578) requires it for the Content-Disposition header to be valid. ("The Content-Disposition header field MUST also contain an additional parameter of "name"".)

This resolves #125.