### PR TITLE
Expose raw response in base_stream

### DIFF
--- a/lib/anthropic/internal/type/base_stream.rb
+++ b/lib/anthropic/internal/type/base_stream.rb
@@ -58,6 +58,11 @@ module Anthropic
 
         alias_method :enum_for, :to_enum
 
+        # @api public
+        #
+        # @return [Net::HTTPResponse]
+        def response = @response
+
         # @api private
         #
         # @param model [Class, Anthropic::Internal::Type::Converter]


### PR DESCRIPTION
Closes https://github.com/anthropics/anthropic-sdk-ruby/issues/110

This simply exposes the response