### PR TITLE
chore: add `cgi` gem as explicit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     anthropic (1.16.3)
+      cgi
       connection_pool
 
 GEM
@@ -57,6 +58,7 @@ GEM
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
+    cgi (0.5.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     console (1.34.2)

--- a/anthropic.gemspec
+++ b/anthropic.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
     ".ignore"
   ]
   s.extra_rdoc_files = ["README.md"]
+  s.add_dependency "cgi"
   s.add_dependency "connection_pool"
 end


### PR DESCRIPTION
`cgi` gem is removed from the default gems in Ruby 4.0. https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#stdlib-compatibility-issues

We need to add it as explicit dependency it because we use `CGI.parse`.

Fixes #147.