### PR TITLE
chore: add `base64` gem as explicit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     anthropic (1.23.0)
+      base64
       cgi
       connection_pool
 

--- a/anthropic.gemspec
+++ b/anthropic.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
     ".ignore"
   ]
   s.extra_rdoc_files = ["README.md"]
+  s.add_dependency "base64"
   s.add_dependency "cgi"
   s.add_dependency "connection_pool"
 end


### PR DESCRIPTION
`base64` is promoted to bundled gem since Ruby 3.4. https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#standard-library-updates

So without this change, users may get the following error when using `anthropic` gem with Bundler.

```
lib/ruby/gems/4.0.0/gems/anthropic-1.23.0/lib/anthropic.rb:6: warning: base64 used to be loaded from the standard library, but is not part of the default gems since Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to fix this error.
lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- base64 (LoadError)
```

**Note**

It looks like `anthropic` doesn't use `base64` gem inside lib.

```bash
$ git grep "Base64\."
examples/images.rb:            data: Base64.strict_encode64(image)
```

Loading of `base64` was add by b1c7dab8e980c491eb6a8d251a6af473724d8a57. I can't understand the reason of that change. So I choose to keep it just in case.