### PR TITLE
docs: remove outdated single-content-block note from accumulated_text

### DIFF
--- a/lib/anthropic/helpers/messages.rb
+++ b/lib/anthropic/helpers/messages.rb
@@ -9,7 +9,7 @@ module Anthropic
         # Extract tool models from the request and convert them to JSON Schema
         # Returns a hash mapping tool name to Ruby model.
         #
-        # @param data [Hash{Sybmol=>Object}]
+        # @param data [Hash{Symbol=>Object}]
         #
         # @param strict [Boolean, nil]
         #
@@ -115,13 +115,13 @@ module Anthropic
 
         # @api private
         #
-        # @param raw [Hash{Sybmol=>Object}]
+        # @param raw [Hash{Symbol=>Object}]
         #
         # @param tools [Hash{String=>Class}]
         #
         # @param models [Hash{String=>Class}]
         #
-        # @return [Hash{Sybmol=>Object}]
+        # @return [Hash{Symbol=>Object}]
         def parse_input_schemas!(raw, tools:, models:)
           raw[:content]&.each do |content|
             case content

--- a/lib/anthropic/helpers/streaming/message_stream.rb
+++ b/lib/anthropic/helpers/streaming/message_stream.rb
@@ -70,7 +70,6 @@ module Anthropic
         # @api public
         #
         # Returns all text content blocks concatenated into a single string.
-        # NOTE: Currently the API will only respond with a single content block.
         #
         # Will raise an error if no `text` content blocks were returned.
         # @return [String]


### PR DESCRIPTION
## Summary

Removes a stale documentation note from `accumulated_text` in `lib/anthropic/helpers/streaming/message_stream.rb`.

## Change

Removes the comment:
```ruby
# NOTE: Currently the API will only respond with a single content block.
```

from the `accumulated_text` method.

## Why

This note was accurate at the time it was written, but has been outdated since extended thinking was introduced. When thinking is enabled the API returns a `thinking` block followed by a `text` block, i.e. multiple content blocks. The implementation already handles this correctly (it maps over all blocks and joins text ones); only the misleading comment needed removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)