### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -23,7 +23,7 @@ jobs:
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0 (sha-pinned)
         with:
           bundler-cache: false
 


### PR DESCRIPTION
Pin third-party GitHub Actions references to immutable commit SHAs.