### PR TITLE
fix(credentials): make workload_identity.rb survive bootsnap's iseq precompile on Ruby 4

### DIFF
--- a/lib/anthropic/credentials/workload_identity.rb
+++ b/lib/anthropic/credentials/workload_identity.rb
@@ -156,17 +156,18 @@ module Anthropic
         end
 
         data = JSON.parse(response.body, symbolize_names: true)
-        # NOTE: kept as two separate `in` clauses (Integer / String) rather than
-        # `(Integer | String) => expires_in`. The alternative-pattern-with-capture
-        # form parses fine on Ruby 4 but is rejected by
-        # `RubyVM::InstructionSequence.compile_file` with
-        # `alternative pattern after variable capture (SyntaxError)`, which
-        # breaks bootsnap's iseq-precompile pass (i.e. every Rails boot).
         token, expires_in =
           case data
-          in {access_token: String => token, expires_in: Integer => expires_in}
-            [token, expires_in.to_i]
-          in {access_token: String => token, expires_in: String => expires_in}
+          # NOTE: `expires_in` is matched before `access_token` deliberately. On Ruby
+          # 4.0.1-4.0.3 built with Prism, `RubyVM::InstructionSequence.compile_file`
+          # falls back to the old parser (https://bugs.ruby-lang.org/issues/22023),
+          # which rejects an alternative pattern that follows a variable capture. Put
+          # `access_token: String => token` first and loading this file raises
+          # `alternative pattern after variable capture (SyntaxError)` under
+          # bootsnap's iseq precompile, i.e. on Rails boot. Fixed in Ruby 4.0.4 and
+          # worked around in bootsnap 1.24.2; this order keeps older combinations
+          # loadable.
+          in {expires_in: (Integer | String) => expires_in, access_token: String => token}
             [token, expires_in.to_i]
           in {access_token: String => token}
             [token, 3600]

--- a/lib/anthropic/credentials/workload_identity.rb
+++ b/lib/anthropic/credentials/workload_identity.rb
@@ -163,10 +163,10 @@ module Anthropic
           # falls back to the old parser (https://bugs.ruby-lang.org/issues/22023),
           # which rejects an alternative pattern that follows a variable capture. Put
           # `access_token: String => token` first and loading this file raises
-          # `alternative pattern after variable capture (SyntaxError)` under
-          # bootsnap's iseq precompile, i.e. on Rails boot. Fixed in Ruby 4.0.4 and
-          # worked around in bootsnap 1.24.2; this order keeps older combinations
-          # loadable.
+          # `alternative pattern after variable capture (SyntaxError)` under bootsnap
+          # 1.24.0-1.24.1 -- they dropped the `rescue SyntaxError` fallback earlier
+          # versions had, and predate the 1.24.2 Prism workaround -- which breaks
+          # Rails boot. Fixed in Ruby 4.0.4.
           in {expires_in: (Integer | String) => expires_in, access_token: String => token}
             [token, expires_in.to_i]
           in {access_token: String => token}

--- a/lib/anthropic/credentials/workload_identity.rb
+++ b/lib/anthropic/credentials/workload_identity.rb
@@ -156,9 +156,17 @@ module Anthropic
         end
 
         data = JSON.parse(response.body, symbolize_names: true)
+        # NOTE: kept as two separate `in` clauses (Integer / String) rather than
+        # `(Integer | String) => expires_in`. The alternative-pattern-with-capture
+        # form parses fine on Ruby 4 but is rejected by
+        # `RubyVM::InstructionSequence.compile_file` with
+        # `alternative pattern after variable capture (SyntaxError)`, which
+        # breaks bootsnap's iseq-precompile pass (i.e. every Rails boot).
         token, expires_in =
           case data
-          in {access_token: String => token, expires_in: (Integer | String) => expires_in}
+          in {access_token: String => token, expires_in: Integer => expires_in}
+            [token, expires_in.to_i]
+          in {access_token: String => token, expires_in: String => expires_in}
             [token, expires_in.to_i]
           in {access_token: String => token}
             [token, 3600]


### PR DESCRIPTION
## Summary

Reorders the hash-pattern keys in `lib/anthropic/credentials/workload_identity.rb#perform_exchange` so the `expires_in` alternative pattern is matched *before* the `access_token` capture. The offending shape is an alternative pattern that follows a variable capture — `{access_token: String => token, expires_in: (Integer | String) => expires_in}` — which parses fine but is rejected by `RubyVM::InstructionSequence.compile_file` on some Ruby 4 builds. Bootsnap (Rails' default) calls `compile_file` on every required file, so `require "anthropic"` aborts Rails boot on those builds.

One-line change, no behavior change: hash-pattern key order doesn't affect what matches.

> **Read the [scope note](#scope-this-may-not-be-worth-carrying) before merging.** While verifying this I found the affected set is far narrower than my original report: exactly ruby 4.0.1–4.0.3 with bootsnap 1.24.0–1.24.1, fixed on both sides since early May 2026. That makes this defensive rather than necessary, and I'm happy for it to be closed.

## Root cause

It's https://bugs.ruby-lang.org/issues/22023: on Prism builds, `RubyVM::InstructionSequence.compile_file` falls back to the *old* parser instead of Prism, and the old parser rejects `alternative pattern after variable capture`. That's why `ruby -c` and a plain `require` are happy while `compile_file` is not — they don't go through the same parser.

This is also why the earlier fixes didn't land it. #188 reported the original error on `Integer | String => expires_in`; #189 added parens. That satisfied the source-level parser, so the issue was closed — but the parenthesized form is still an alternative pattern after a capture, so `compile_file` still rejected it.

## The diff

```ruby
# Before (post-#189, current main)
in {access_token: String => token, expires_in: (Integer | String) => expires_in}

# After
in {expires_in: (Integer | String) => expires_in, access_token: String => token}
```

With the alternative pattern first, there is no preceding capture to trip on. A comment on that line records why the order is load-bearing.

## Verification

Bisected `compile_file` against the real file — the divergence exists on **4.0.1–4.0.3** and is **fixed in 4.0.4**:

| ruby | 3.2.0 | 4.0.1 | 4.0.2 | 4.0.3 | 4.0.4 | 4.0.5 | 4.0.6 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `main` | OK | **SyntaxError** | **SyntaxError** | **SyntaxError** | OK | OK | OK |
| this PR | OK | OK | OK | OK | OK | OK | OK |

End-to-end `require "anthropic"` under real bootsnap, not a synthetic `compile_file` call. Only two bootsnap releases are affected — up to 1.23.0 `input_to_storage` wrapped `compile_file` in `rescue SyntaxError => UNCOMPILABLE` and fell back to a plain `require`; 1.24.0 removed that rescue; 1.24.2 added the Prism workaround:

| bootsnap (ruby 4.0.1, `main`) | result | why |
| --- | --- | --- |
| 1.18.6 / 1.21.1 / 1.23.0 | OK | rescues SyntaxError |
| 1.24.0 / 1.24.1 | **SyntaxError** | rescue removed |
| 1.24.2 / 1.24.6 / 1.25.0 | OK | Prism workaround |

With this PR, every cell above is OK, as is ruby 4.0.4 with any of them.

Also:

- **rubocop**, CI's exact invocation (`--except Lint/RedundantCopDisableDirective,Layout/LineLength`): 947 files, no offenses.
- **`workload_identity_test`**: 10 runs, 33 assertions, 0 failures on both 3.2.0 and 4.0.1.
- **Full suite**: identical to `main` — 445 runs, 0 failures, 75 errors, all pre-existing `APIConnectionError` from the absent mock server.
- **Behavioral equivalence**: old and new forms agree on all 12 payload shapes I tried (integer, numeric string, non-numeric string, missing, `nil`, float, extra keys, non-string token, missing token, `{}`, negative, empty token).

## Scope: this may not be worth carrying

Three things I found while verifying, which narrow the problem a lot:

- Ruby **4.0.4** (2026-05-12) fixes the divergence (bisect above).
- bootsnap **1.24.2** (2026-05-04) works around it, routing `compile_file` through `compile_file_prism`.
- bootsnap **up to 1.23.0 was never affected** — it rescued the SyntaxError and fell back to a plain `require`. Only 1.24.0 (2026-04-26) and 1.24.1 (2026-04-28), which dropped that rescue, actually break.

So the failing combination is exactly **ruby 4.0.1–4.0.3 × bootsnap 1.24.0–1.24.1** — two releases that were current for about eight days, three and a half months ago — and `bundle update bootsnap` escapes it. On the bug itself I'd now lean toward closing this.

The argument I'd still make isn't about this bug. `alternative pattern after variable capture` has proven fragile across CRuby's parser paths: bootsnap carries workarounds for [#18250](https://bugs.ruby-lang.org/issues/18250) and [#22023](https://bugs.ruby-lang.org/issues/22023), and its 1.24.6 entry is a *third* correction to the detection for #22023 on some Ruby 3.4 patches. Generated code that never emits an alternative pattern after a capture avoids that class outright, at zero semantic cost. That's a generator-template argument rather than an SDK-patch one — so it may belong in Stainless, or nowhere, rather than here. Your call, and I'm happy to close it myself.

## Generated-code note

`CONTRIBUTING.md` says modifications to generated files persist across regenerations. If this file comes from a Stainless template, the template needs the same ordering, or the next regen reintroduces the shape — the key order here is load-bearing, which is exactly the kind of thing a generator won't preserve by accident. Happy to take a pointer on which template to touch.

## Out of scope

- No formatting or unrelated changes; no version bump or changelog edit.
- No regression test yet. A `compile_file` assertion would pin the key order against a future regen — happy to add it if you want it, and where.

Related: #188, #189, https://bugs.ruby-lang.org/issues/22023.
