### PR TITLE
fix(streaming): rename @accumated_ -> @accumulated_message_snapshot

### DIFF
--- a/lib/anthropic/helpers/streaming/message_stream.rb
+++ b/lib/anthropic/helpers/streaming/message_stream.rb
@@ -24,11 +24,11 @@ module Anthropic
         private def iterator
           @iterator ||= Anthropic::Internal::Util.chain_fused(@stream) do |y|
             @raw_stream.each do |raw_event|
-              @accumated_message_snapshot = accumulate_event(
+              @accumulated_message_snapshot = accumulate_event(
                 event: raw_event,
-                current_snapshot: @accumated_message_snapshot
+                current_snapshot: @accumulated_message_snapshot
               )
-              events_to_yield = build_events(event: raw_event, message_snapshot: @accumated_message_snapshot)
+              events_to_yield = build_events(event: raw_event, message_snapshot: @accumulated_message_snapshot)
               events_to_yield.each(&y)
             end
           end
@@ -63,8 +63,8 @@ module Anthropic
         # @return [Anthropic::Models::Message, Anthropic::Models::Beta::BetaMessage]
         def accumulated_message
           until_done
-          parse_content_blocks!(@accumated_message_snapshot)
-          @accumated_message_snapshot
+          parse_content_blocks!(@accumulated_message_snapshot)
+          @accumulated_message_snapshot
         end
 
         # @api public
@@ -311,7 +311,7 @@ module Anthropic
           # The underlying Server-Sent Event stream from the Anthropic API.
           @raw_stream = raw_stream
           # Accumulated message state that builds up as events are processed.
-          @accumated_message_snapshot = nil
+          @accumulated_message_snapshot = nil
           # Mapping of tool names to model classes for parsing.
           @tools = tools
           @models = models

--- a/sig/anthropic/helpers/streaming/message_stream.rbs
+++ b/sig/anthropic/helpers/streaming/message_stream.rbs
@@ -23,7 +23,7 @@ module Anthropic
         include Anthropic::Internal::Type::BaseStream[raw_message_event, stream_event]
 
         @raw_stream: Anthropic::Internal::Stream[raw_message_event]
-        @accumated_message_snapshot: Anthropic::Models::message?
+        @accumulated_message_snapshot: Anthropic::Models::message?
         @iterator: Enumerable[stream_event]?
 
         def initialize: (


### PR DESCRIPTION
## Summary
- Renames the misspelled instance variable `@accumated_message_snapshot` to `@accumulated_message_snapshot` to match the public reader `accumulated_message`.
- 6 occurrences in `lib/anthropic/helpers/streaming/message_stream.rb`, 1 in the matching RBS sig.
- Pure cosmetic — no behavioural change.

## Safety vs. the generator
- `CONTRIBUTING.md` states: "The generator will never modify the contents of `lib/anthropic/helpers/` and `examples/` directory."
- The RBS file (`sig/.../message_stream.rbs`) has no `@generated` / `stainless` / `DO NOT EDIT` header.

## Verification
- `ruby -c` on the modified `.rb` -> Syntax OK
- Streaming-specific test file: 5 runs / 11 assertions / 0 failures
- Full helpers test suite: 179 runs / 427 assertions / 0 failures / 8 skips
- No external references to the old variable name (grep)
