### PR TITLE
fix(internal): decode headerless responses using request accept

### DIFF
--- a/lib/anthropic/internal/transport/base_client.rb
+++ b/lib/anthropic/internal/transport/base_client.rb
@@ -691,7 +691,11 @@ module Anthropic
             send_retry_header: send_retry_header
           )
 
-          decoded = Anthropic::Internal::Util.decode_content(headers, stream: stream)
+          decoded = Anthropic::Internal::Util.decode_content(
+            headers,
+            stream: stream,
+            accept: request.fetch(:headers)["accept"]
+          )
           case req
           in {stream: Class => st}
             st.new(

--- a/lib/anthropic/internal/util.rb
+++ b/lib/anthropic/internal/util.rb
@@ -761,11 +761,22 @@ module Anthropic
         # @param headers [Hash{String=>String}]
         # @param stream [Enumerable<String>]
         # @param suppress_error [Boolean]
+        # @param accept [String, nil] the request's `accept` header, used as the
+        #   expected format when the response omits `content-type`
         #
         # @raise [JSON::ParserError]
         # @return [Object]
-        def decode_content(headers, stream:, suppress_error: false)
-          case (content_type = headers["content-type"])
+        def decode_content(headers, stream:, suppress_error: false, accept: nil)
+          # Some endpoints answer without a `content-type` at all — the batch
+          # results download labels its body with `content-disposition` only.
+          # `Regexp === nil` never matches, so keying purely off the response
+          # header drops those bodies into the raw `else` arm and hands back
+          # unparsed text. Fall back to the format the request asked for, which
+          # the SDK sets itself for every endpoint with a known body shape.
+          content_type = headers["content-type"]
+          content_type = accept if content_type.nil? || content_type.strip.empty?
+
+          case content_type
           in Anthropic::Internal::Util::JSON_CONTENT
             return nil if (json = stream.to_a.join).empty?
 

--- a/lib/anthropic/middleware.rb
+++ b/lib/anthropic/middleware.rb
@@ -321,7 +321,7 @@ module Anthropic
       return @parsed unless Anthropic::Internal::OMIT.equal?(@parsed)
 
       buffer!
-      decoded = Anthropic::Internal::Util.decode_content(@headers, stream: body.each)
+      decoded = Anthropic::Internal::Util.decode_content(@headers, stream: body.each, accept: accept_header)
       unwrapped = Anthropic::Internal::Util.dig(decoded, @request&.unwrap)
       cast_to = @request&.cast_to || Anthropic::Internal::Type::Unknown
       @parsed = Anthropic::Internal::Type::Converter.coerce(cast_to, unwrapped)
@@ -346,12 +346,19 @@ module Anthropic
 
     private
 
+    # The format the request asked for, which {Anthropic::Internal::Util.decode_content}
+    # falls back to when the response carries no `content-type`. `nil` for a
+    # fabricated response with no `request:`.
+    #
+    # @return [String, nil]
+    def accept_header = @request&.headers&.[]("accept")
+
     # A fresh typed stream over a buffered copy of the response body.
     #
     # @return [Anthropic::Internal::Type::BaseStream, Enumerable]
     def parse_stream
       buffer!(force: true)
-      decoded = Anthropic::Internal::Util.decode_content(@headers, stream: body.each)
+      decoded = Anthropic::Internal::Util.decode_content(@headers, stream: body.each, accept: accept_header)
       stream = @request&.stream
       return decoded unless stream
 

--- a/rbi/anthropic/internal/util.rbi
+++ b/rbi/anthropic/internal/util.rbi
@@ -401,10 +401,11 @@ module Anthropic
           params(
             headers: T::Hash[String, String],
             stream: T::Enumerable[String],
-            suppress_error: T::Boolean
+            suppress_error: T::Boolean,
+            accept: T.nilable(String)
           ).returns(T.anything)
         end
-        def decode_content(headers, stream:, suppress_error: false)
+        def decode_content(headers, stream:, suppress_error: false, accept: nil)
         end
       end
 

--- a/sig/anthropic/internal/util.rbs
+++ b/sig/anthropic/internal/util.rbs
@@ -153,7 +153,8 @@ module Anthropic
       def self?.decode_content: (
         ::Hash[String, String] headers,
         stream: Enumerable[String],
-        ?suppress_error: bool
+        ?suppress_error: bool,
+        ?accept: String?
       ) -> top
 
       def self?.fused_enum: (

--- a/test/anthropic/client_test.rb
+++ b/test/anthropic/client_test.rb
@@ -409,6 +409,22 @@ class AnthropicTest < Minitest::Test
     end
   end
 
+  def test_batch_results_without_content_type_use_request_accept
+    body = [
+      {custom_id: "batch-1", result: {type: "canceled"}},
+      {custom_id: "batch-2", result: {type: "canceled"}}
+    ].map { JSON.generate(_1) }.join("\n")
+    stub_request(:get, "http://localhost/v1/messages/batches/msgbatch_abc/results")
+      .with(headers: {"Accept" => "application/x-jsonl"})
+      .to_return(status: 200, headers: {"Content-Disposition" => "attachment"}, body: body)
+
+    anthropic = Anthropic::Client.new(base_url: "http://localhost", api_key: "my-anthropic-api-key")
+    results = anthropic.messages.batches.results_streaming("msgbatch_abc").to_a
+
+    assert_equal(%w[batch-1 batch-2], results.map(&:custom_id))
+    assert(results.all? { _1.is_a?(Anthropic::Messages::MessageBatchIndividualResponse) })
+  end
+
   def test_nonstreaming_timeout_calculation_normal
     anthropic = Anthropic::Client.new(base_url: "http://localhost", api_key: "my-anthropic-api-key")
 

--- a/test/anthropic/internal/util_test.rb
+++ b/test/anthropic/internal/util_test.rb
@@ -615,6 +615,85 @@ class Anthropic::Test::UtilContentDecodingTest < Minitest::Test
       assert_equal(encoding, text.encoding)
     end
   end
+
+  # The batch results download answers with `content-disposition` and no
+  # `content-type`, so the decode falls back to what the request accepted.
+  def test_missing_content_type_falls_back_to_accept
+    decoded = Anthropic::Internal::Util.decode_content(
+      {"content-disposition" => "attachment; filename=results.jsonl"},
+      stream: ["{\"custom_id\":\"a\"}\n", "{\"custom_id\":\"b\"}\n"].each,
+      accept: "application/x-jsonl"
+    )
+
+    assert_equal([{custom_id: "a"}, {custom_id: "b"}], decoded.to_a)
+  end
+
+  def test_blank_content_type_falls_back_to_accept
+    decoded = Anthropic::Internal::Util.decode_content(
+      {"content-type" => "  "},
+      stream: ["{\"a\":1}"].each,
+      accept: "application/json"
+    )
+
+    assert_equal({a: 1}, decoded)
+  end
+
+  def test_response_content_type_wins_over_accept
+    decoded = Anthropic::Internal::Util.decode_content(
+      {"content-type" => "application/json"},
+      stream: ["{\"a\":1}"].each,
+      accept: "application/x-jsonl"
+    )
+
+    assert_equal({a: 1}, decoded)
+  end
+
+  def test_missing_content_type_without_accept_stays_raw
+    decoded = Anthropic::Internal::Util.decode_content({}, stream: ["{\"a\":1}"].each)
+
+    assert_instance_of(StringIO, decoded)
+    assert_equal("{\"a\":1}", decoded.string)
+  end
+
+  def test_unrecognized_accept_stays_raw
+    decoded = Anthropic::Internal::Util.decode_content(
+      {},
+      stream: ["not json"].each,
+      accept: "application/binary"
+    )
+
+    assert_instance_of(StringIO, decoded)
+    assert_equal("not json", decoded.string)
+  end
+end
+
+class Anthropic::Test::JsonLStreamTest < Minitest::Test
+  def test_coerces_lines_from_headerless_response
+    model = Anthropic::Messages::MessageBatchIndividualResponse
+    line = {
+      custom_id: "foo-1",
+      result: {type: "canceled"}
+    }
+    decoded = Anthropic::Internal::Util.decode_content(
+      {"content-disposition" => "attachment; filename=results.jsonl"},
+      stream: ["#{JSON.generate(line)}\n"].each,
+      accept: "application/x-jsonl"
+    )
+    stream = Anthropic::Internal::JsonLStream.new(
+      model: model,
+      url: URI("http://localhost/v1/messages/batches/msgbatch_abc/results"),
+      status: 200,
+      headers: {},
+      response: nil,
+      unwrap: nil,
+      stream: decoded
+    )
+
+    assert_pattern do
+      stream.to_a => [Anthropic::Messages::MessageBatchIndividualResponse => result]
+      result.custom_id => "foo-1"
+    end
+  end
 end
 
 class Anthropic::Test::UtilSseTest < Minitest::Test


### PR DESCRIPTION
Closes #208.

Message Batch result downloads can return JSONL without a `Content-Type` response header. The decoder currently treats those bodies as raw text, so `results_streaming` yields strings instead of typed batch result objects.

This change:

- falls back to the request `Accept` header only when the response `Content-Type` is missing or blank
- keeps an explicit response `Content-Type` authoritative
- leaves unknown formats and error-response decoding behavior unchanged
- updates the RBS and RBI signatures
- adds direct decoder coverage and an end-to-end regression test for `results_streaming`

Tests:

- `ruby -Itest test/anthropic/client_test.rb`
- `ruby -Itest test/anthropic/internal/util_test.rb`
- `ruby -Itest test/anthropic/middleware_test.rb`